### PR TITLE
Helper class and small change for where a2 / b2 is none or not specified

### DIFF
--- a/patchit.py
+++ b/patchit.py
@@ -193,6 +193,9 @@ class PatchSetReader(object):
         if not self._active_patch:
             raise PatchSyntaxError('Missing current patch')
 
+        if hunk_dict['a2'] == None: hunk_dict['a2'] = 0
+        if hunk_dict['b2'] == None: hunk_dict['b2'] = 0
+
         a_range = (int(hunk_dict['a1']), int(hunk_dict['a2']), )
         b_range = (int(hunk_dict['b1']), int(hunk_dict['b2']), )
         self._active_hunk = Hunk(a_range, b_range, hunk_dict.get('comment'))

--- a/patchit_file.py
+++ b/patchit_file.py
@@ -1,0 +1,50 @@
+﻿"""
+Helper class for patching files
+"""
+
+# This module uses patchit from https://pypi.python.org/pypi/patchit/1.1
+
+import os
+from patchit import PatchSet
+from os.path import join, abspath
+
+class PatchitFile(object):
+    """Helper class for patching files"""
+
+    def __init__(self, patchfile, startdir, strip = 0):
+        self.patchfile = patchfile
+        self.startdir = startdir
+        self.strip = strip
+
+    def Apply(self):
+        """Apply a patch file to a directory"""
+
+        with open(self.patchfile) as patch_hand:
+            patches = PatchSet.from_stream(patch_hand)
+
+            for patchitem in patches:
+                # Figure out the path of the file to patch
+                srcpath = PatchitFile.StripPath(patchitem.source_filename, self.strip)
+                srcpath = abspath(join(self.startdir, srcpath))
+                
+                with open(srcpath) as srcfile_hand:
+                    # Get a read handle to the file to patch
+                    srcfile_iter = (x.strip('\n') for x in iter(srcfile_hand.readline, ''))
+                    # Read in the file and patch in memory
+                    outlist = list(patchitem.merge(srcfile_iter))
+
+                    # Overwrite the output file
+                    with open(srcpath, 'w') as file:
+                        for item in outlist:
+                            file.write("{}\n".format(item))
+        return
+
+    @staticmethod
+    def StripPath(filepath, strip = 0):
+        """Strip parts from the front of a relative path, the same as -pX with gnu patch"""
+
+        pathparts = filepath.split(os.sep)
+        for x in range(0, strip):
+            pathparts.pop(0)
+        retpath = join(*pathparts)
+        return retpath


### PR DESCRIPTION
Hi, I've been using the patchit module because it seems to be one of the few python ones compatible with python 3
I've added a small helper class to make patching files easier
also I noticed when running diff -Naur against a couple of directories sometimes a2 / b2 is not specified so should be assumed to be 0 instead of None

as an example

diff -Naur original\sox/libgsm/CMakeLists.txt packages\sox/libgsm/CMakeLists.txt
--- original\sox/libgsm/CMakeLists.txt  Wed Mar  2 22:10:27 2011
+++ packages\sox/libgsm/CMakeLists.txt  Thu Aug 20 10:59:03 2015
**@@ -1 +1,9 @@**
 add_library(gsm add code decode gsm_create gsm_decode gsm_destroy gsm_encode gsm_option long_term lpc preprocess rpe short_term table)
+
+# Set the Output Directory for libs
+set_target_properties( gsm
-    PROPERTIES
-    ARCHIVE_OUTPUT_DIRECTORY "${CMAKE_CURRENT_BINARY_DIR}/../../LibOutput"
-    LIBRARY_OUTPUT_DIRECTORY "${CMAKE_CURRENT_BINARY_DIR}/../../LibOutput"
-    RUNTIME_OUTPUT_DIRECTORY "${CMAKE_CURRENT_BINARY_DIR}/../../LibOutput"
  +)
